### PR TITLE
add generics support

### DIFF
--- a/astcopy.go
+++ b/astcopy.go
@@ -3,6 +3,8 @@ package astcopy
 
 import (
 	"go/ast"
+
+	"golang.org/x/exp/typeparams"
 )
 
 // Node returns x node deep copy.
@@ -341,6 +343,9 @@ func FuncType(x *ast.FuncType) *ast.FuncType {
 	cp := *x
 	cp.Params = FieldList(x.Params)
 	cp.Results = FieldList(x.Results)
+	if typeParams := typeparams.ForFuncType(x); typeParams != nil {
+		*typeparams.ForFuncType(&cp) = *FieldList(typeParams)
+	}
 	return &cp
 }
 
@@ -429,6 +434,9 @@ func TypeSpec(x *ast.TypeSpec) *ast.TypeSpec {
 	cp.Type = copyExpr(x.Type)
 	cp.Doc = CommentGroup(x.Doc)
 	cp.Comment = CommentGroup(x.Comment)
+	if typeParams := typeparams.ForTypeSpec(x); typeParams != nil {
+		*typeparams.ForTypeSpec(&cp) = *FieldList(typeParams)
+	}
 	return &cp
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/go-toolsmith/astcopy
 
+go 1.16
+
 require (
-	github.com/go-toolsmith/astequal v1.0.0
+	github.com/go-toolsmith/astequal v1.0.2
 	github.com/go-toolsmith/strparse v1.0.0
+	golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/go-toolsmith/astequal v1.0.0 h1:4zxD8j3JRFNyLN46lodQuqz3xdKSrur7U/sr0SDS/gQ=
-github.com/go-toolsmith/astequal v1.0.0/go.mod h1:H+xSiq0+LtiDC11+h1G32h7Of5O3CYFJ99GVbS5lDKY=
+github.com/go-toolsmith/astequal v1.0.2 h1:+XvaV8zNxua+9+Oa4AHmgmpo4RYAbwr/qjNppLfX2yM=
+github.com/go-toolsmith/astequal v1.0.2/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
 github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUDxe2Jb4=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171 h1:DZhP7zSquENyG3Yb6ZpGqNEtgE8dfXhcLcheIF9RQHY=
+golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=


### PR DESCRIPTION
Type params are accessed via `typeparams` package, so `astcopy`
should continue to work for older Go releases.