### PR TITLE
Fix copying TypeParams

### DIFF
--- a/astcopy.go
+++ b/astcopy.go
@@ -346,21 +346,6 @@ func FieldList(x *ast.FieldList) *ast.FieldList {
 	return &cp
 }
 
-// FuncType returns x deep copy.
-// Copy of nil argument is nil.
-func FuncType(x *ast.FuncType) *ast.FuncType {
-	if x == nil {
-		return nil
-	}
-	cp := *x
-	cp.Params = FieldList(x.Params)
-	cp.Results = FieldList(x.Results)
-	if typeParams := typeparams.ForFuncType(x); typeParams != nil {
-		*typeparams.ForFuncType(&cp) = *FieldList(typeParams)
-	}
-	return &cp
-}
-
 // InterfaceType returns x deep copy.
 // Copy of nil argument is nil.
 func InterfaceType(x *ast.InterfaceType) *ast.InterfaceType {
@@ -432,23 +417,6 @@ func ValueSpec(x *ast.ValueSpec) *ast.ValueSpec {
 	cp.Type = copyExpr(x.Type)
 	cp.Doc = CommentGroup(x.Doc)
 	cp.Comment = CommentGroup(x.Comment)
-	return &cp
-}
-
-// TypeSpec returns x deep copy.
-// Copy of nil argument is nil.
-func TypeSpec(x *ast.TypeSpec) *ast.TypeSpec {
-	if x == nil {
-		return nil
-	}
-	cp := *x
-	cp.Name = Ident(x.Name)
-	cp.Type = copyExpr(x.Type)
-	cp.Doc = CommentGroup(x.Doc)
-	cp.Comment = CommentGroup(x.Comment)
-	if typeParams := typeparams.ForTypeSpec(x); typeParams != nil {
-		*typeparams.ForTypeSpec(&cp) = *FieldList(typeParams)
-	}
 	return &cp
 }
 

--- a/astcopy_go117.go
+++ b/astcopy_go117.go
@@ -1,0 +1,30 @@
+//go:build !go1.18
+// +build !go1.18
+
+package astcopy
+
+// FuncType returns x deep copy.
+// Copy of nil argument is nil.
+func FuncType(x *ast.FuncType) *ast.FuncType {
+	if x == nil {
+		return nil
+	}
+	cp := *x
+	cp.Params = FieldList(x.Params)
+	cp.Results = FieldList(x.Results)
+	return &cp
+}
+
+// TypeSpec returns x deep copy.
+// Copy of nil argument is nil.
+func TypeSpec(x *ast.TypeSpec) *ast.TypeSpec {
+	if x == nil {
+		return nil
+	}
+	cp := *x
+	cp.Name = Ident(x.Name)
+	cp.Type = copyExpr(x.Type)
+	cp.Doc = CommentGroup(x.Doc)
+	cp.Comment = CommentGroup(x.Comment)
+	return &cp
+}

--- a/astcopy_go118.go
+++ b/astcopy_go118.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+package astcopy
+
+import (
+	"go/ast"
+)
+
+// FuncType returns x deep copy.
+// Copy of nil argument is nil.
+func FuncType(x *ast.FuncType) *ast.FuncType {
+	if x == nil {
+		return nil
+	}
+	cp := *x
+	cp.Params = FieldList(x.Params)
+	cp.Results = FieldList(x.Results)
+	cp.TypeParams = FieldList(x.TypeParams)
+	return &cp
+}
+
+// TypeSpec returns x deep copy.
+// Copy of nil argument is nil.
+func TypeSpec(x *ast.TypeSpec) *ast.TypeSpec {
+	if x == nil {
+		return nil
+	}
+	cp := *x
+	cp.Name = Ident(x.Name)
+	cp.Type = copyExpr(x.Type)
+	cp.Doc = CommentGroup(x.Doc)
+	cp.Comment = CommentGroup(x.Comment)
+	cp.TypeParams = FieldList(x.TypeParams)
+	return &cp
+}


### PR DESCRIPTION
There was a bug where the TypeParams weren't being properly copied but rather continuing the use the source value.

The code:

```
cp := *x
if typeParams := typeparams.ForFuncType(x); typeParams != nil {
	*typeparams.ForFuncType(&cp) = *FieldList(typeParams)
}
```

cp.TypeParams which typeparams.ForFyncType returns is still x.TypeParams. Then the `*typeparams.ForFuncType(&cp)` overwrites it a copy thus modifying the original slice.

This issue causes a data race which showed up in golangci-lint and often caused a panic.

The only way around this I found was to have copies of the function for different versions of Go since the typeparam package doesn't have a way to set the TypeParams field.